### PR TITLE
main

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -132,7 +132,7 @@ let additions =
         , repo =
             "https://github.com/i-am-the-slime/purescript-justifill.git"
         , version =
-            "e443bde"
+            "4f84ba6" 
         }
     }
 

--- a/src/AWS/CostExplorer/CostExplorer.purs
+++ b/src/AWS/CostExplorer/CostExplorer.purs
@@ -13,8 +13,9 @@ import Data.Nullable (Nullable, notNull, toMaybe, toNullable)
 import Effect (Effect)
 import Effect.Aff (Aff)
 import Foreign (Foreign)
-import Justifill.Fillable (class FillableFields)
-import Justifill.Justifiable (class JustifiableFields)
+import Justifill (justifill)
+import Justifill.Fillable (class Fillable, class FillableFields, fill)
+import Justifill.Justifiable (class Justifiable, class JustifiableFields, justify)
 import Prim.Row (class Union)
 import Prim.RowList (class RowToList)
 
@@ -23,15 +24,18 @@ foreign import data CE :: Type
 foreign import newCE :: Foreign -> (Effect CE)
 
 makeClient ::
-  forall propsRowList rl r2 props clientProps.
-  RowToList r2 rl =>
-  FillableFields rl () r2 =>
-  Union clientProps r2 DefaultClientPropsR =>
-  RowToList props propsRowList =>
-  JustifiableFields propsRowList props () clientProps =>
-  Record props ->
+  forall given justified.
+  Justifiable { | given } justified =>
+  Fillable justified DefaultClientProps =>
+  { | given } ->
   Effect CE
-makeClient r = ((makeDefaultClient r :: DefaultClientProps)) # makeClientHelper newCE
+makeClient r = justifilled # makeClientHelper newCE
+  where
+  justified :: justified
+  justified = justify r
+
+  justifilled :: DefaultClientProps
+  justifilled = fill justified
 
 -- https://github.com/aws/aws-sdk-js/blob/dabf8b11e6e0d61d4dc2ab62717b8735fb8b29e4/clients/costexplorer.d.ts#L649
 type InternalGetCostAndUsageResponse

--- a/src/AWS/CostExplorer/CostExplorer.purs
+++ b/src/AWS/CostExplorer/CostExplorer.purs
@@ -28,10 +28,13 @@ makeClient ::
   Fillable { | via } DefaultClientProps =>
   { | r } ->
   Effect CE
-makeClient r = (justifillVia viaProxy r :: DefaultClientProps) # makeClientHelper newCE
+makeClient r = makeClientHelper newCE props
   where
   viaProxy :: Proxy { | via }
   viaProxy = Proxy
+
+  props :: DefaultClientProps
+  props = justifillVia viaProxy r
 
 -- https://github.com/aws/aws-sdk-js/blob/dabf8b11e6e0d61d4dc2ab62717b8735fb8b29e4/clients/costexplorer.d.ts#L649
 type InternalGetCostAndUsageResponse

--- a/src/AWS/CostExplorer/CostExplorer.purs
+++ b/src/AWS/CostExplorer/CostExplorer.purs
@@ -1,8 +1,8 @@
 module AWS.CostExplorer where
 
 import Prelude
-import AWS.Core.Client (makeClientHelper, makeDefaultClient)
-import AWS.Core.Types (DefaultClientPropsR, DefaultClientProps)
+import AWS.Core.Client (makeClientHelper)
+import AWS.Core.Types (DefaultClientProps)
 import AWS.Core.Util (raiseEither, toIso8601Date)
 import Control.Promise (Promise)
 import Control.Promise as Promise
@@ -13,29 +13,25 @@ import Data.Nullable (Nullable, notNull, toMaybe, toNullable)
 import Effect (Effect)
 import Effect.Aff (Aff)
 import Foreign (Foreign)
-import Justifill (justifill)
-import Justifill.Fillable (class Fillable, class FillableFields, fill)
-import Justifill.Justifiable (class Justifiable, class JustifiableFields, justify)
-import Prim.Row (class Union)
-import Prim.RowList (class RowToList)
+import Justifill (justifillVia)
+import Justifill.Fillable (class Fillable)
+import Justifill.Justifiable (class Justifiable)
+import Type.Proxy (Proxy(..))
 
 foreign import data CE :: Type
 
 foreign import newCE :: Foreign -> (Effect CE)
 
 makeClient ::
-  forall given justified.
-  Justifiable { | given } justified =>
-  Fillable justified DefaultClientProps =>
-  { | given } ->
+  forall r via.
+  Justifiable { | r } { | via } =>
+  Fillable { | via } DefaultClientProps =>
+  { | r } ->
   Effect CE
-makeClient r = justifilled # makeClientHelper newCE
+makeClient r = (justifillVia viaProxy r :: DefaultClientProps) # makeClientHelper newCE
   where
-  justified :: justified
-  justified = justify r
-
-  justifilled :: DefaultClientProps
-  justifilled = fill justified
+  viaProxy :: Proxy { | via }
+  viaProxy = Proxy
 
 -- https://github.com/aws/aws-sdk-js/blob/dabf8b11e6e0d61d4dc2ab62717b8735fb8b29e4/clients/costexplorer.d.ts#L649
 type InternalGetCostAndUsageResponse

--- a/src/AWS/CostExplorer/CostExplorer.purs
+++ b/src/AWS/CostExplorer/CostExplorer.purs
@@ -1,7 +1,6 @@
 module AWS.CostExplorer where
 
 import Prelude
-
 import AWS.Core.Client (makeClientHelper, makeDefaultClient)
 import AWS.Core.Types (DefaultClientPropsR, DefaultClientProps)
 import AWS.Core.Util (raiseEither, toIso8601Date)
@@ -23,12 +22,16 @@ foreign import data CE :: Type
 
 foreign import newCE :: Foreign -> (Effect CE)
 
-
-makeClient :: forall t4 t5 t6 t7 t8.
-  RowToList t6 t5 => FillableFields t5 () t6 => Union t8 t6
-                                                  DefaultClientPropsR
-                                                 => RowToList t7 t4 => JustifiableFields t4 t7 () t8 => Record t7 -> Effect CE
-makeClient r = ((makeDefaultClient r:: DefaultClientProps)) # makeClientHelper newCE
+makeClient ::
+  forall propsRowList rl r2 props clientProps.
+  RowToList r2 rl =>
+  FillableFields rl () r2 =>
+  Union clientProps r2 DefaultClientPropsR =>
+  RowToList props propsRowList =>
+  JustifiableFields propsRowList props () clientProps =>
+  Record props ->
+  Effect CE
+makeClient r = ((makeDefaultClient r :: DefaultClientProps)) # makeClientHelper newCE
 
 -- https://github.com/aws/aws-sdk-js/blob/dabf8b11e6e0d61d4dc2ab62717b8735fb8b29e4/clients/costexplorer.d.ts#L649
 type InternalGetCostAndUsageResponse


### PR DESCRIPTION
@hivemind-js asked me to have a look at the complicated type signature and try to simplify it.

## Problem
It's indeed a little tricky to call `justifill` from a function that receives a dynamic input since there are no concrete types for the compiler to infer. This is because `justifill` performs two steps at once: `justify` and `fill`. 

## Background 
Let's look at some examples.

### Examples
```purescript
example :: { age :: Maybe Int, name :: Maybe String }
example = justifill { age: 88 }
-- produces { age: Just 88, name: Nothing  } 
```
This is the same as
``` purescript
example = do
  let justified = justify { age: 88 } -- produces { age: Just 88 } 
  fill justified -- produces { age: Just 88, name: Nothing } again
```

### Typeclasses
In order for something like this to compile, the compiler needs an instance of two typeclasses for the records we're dealing with: `Justifiable` and `Fillable`.
For our specific example these are `Justifiable { age :: Int } { age :: Maybe Int }` and `Fillable { age :: Maybe Int } { age :: Maybe Int, name :: Maybe String}`. 

When dealing with concrete input and output types, the compiler can correctly infer the intermediate type. When we write more generic functions that wrap a call to `justifill` the actual types potentially differ on each invocation.

This PR is split into four commits. The first one introduces new names for the existing type annotation that I introduced to be able to make more sense of it.

The second step uses the individual `justify` and `fill` functions as in the implementation of `justifill`. This helps because it gives the opportunity to annotate the intermediate type.

I also added a new function to `purescript-justifill` called `justifillVia` that takes a `Proxy` of the intermediate type. That's what I use in the last two commits.

A `Proxy` is a useless value that one creates as such:

```purescript
Proxy :: Proxy someType
```

`justifillVia` will use the type of the supplied proxy as the type for the intermediate record to construct.

I personally prefer the solution in the `Use two steps` commit, though.

- Improve names
- Using two steps
- Use justifillVia
- Uninline function call