### PR TITLE
Make getMetricStatistics parametrizable

### DIFF
--- a/src/AWS/CloudWatch/Cloudwatch.purs
+++ b/src/AWS/CloudWatch/Cloudwatch.purs
@@ -1,18 +1,20 @@
 module AWS.CloudWatch
   ( CloudWatch
   , makeClient
-  , InternalGetMetricStatisticsOutput
-  , InternalMetricDatapoint
-  , getMetricStatistics
+  , getMetricStatisticsAverage
+  , getMetricStatisticsMaximum
   ) where
 
 import Prelude
+
+import AWS.CloudWatch.Types (Dimension, GetMetricStatisticsOutput, MetricDatapointMaximum, MetricSettings, Statistics, MetricDatapointAverage)
 import AWS.Core.Client (makeClientHelper)
-import AWS.Core.Types (DefaultClientProps, InstanceId)
+import AWS.Core.Types (DefaultClientProps)
 import AWS.Core.Util (handleError)
 import Control.Promise (Promise)
 import Control.Promise as Promise
-import Data.Argonaut (Json, decodeJson, parseJson)
+import Data.Argonaut (Json, parseJson)
+import Data.Argonaut.Decode (decodeJson)
 import Data.Bifunctor (lmap)
 import Data.DateTime (DateTime)
 import Data.Either (Either)
@@ -55,36 +57,77 @@ type InternalGetMetricsStatisticsParams
     , "Statistics" :: Array String
     }
 
-type InternalMetricDatapoint
-  = { "Timestamp" :: String
-    , "Maximum" :: Number
-    , "Unit" :: String
-    }
+type InternalDimension
+  = { "Name" :: String, "Value" :: String }
 
-type InternalGetMetricStatisticsOutput
-  = { "ResponseMetadata" :: { "RequestId" :: String }
-    , "Label" :: String
-    , "Datapoints" :: Array InternalMetricDatapoint
-    }
+toInternalDimension :: Dimension -> InternalDimension
+toInternalDimension dimension =
+  { "Name": show dimension.name
+  , "Value": unwrap dimension.value
+  }
 
-foreign import data GetMetricStatisticsResponse :: Type
+toInternalGetMetricStatisticsParams ::
+  forall a.
+  { start :: DateTime, end :: DateTime | a } ->
+  Statistics ->
+  MetricSettings ->
+  InternalGetMetricsStatisticsParams
+toInternalGetMetricStatisticsParams range statistics ms =
+  { "Namespace": nameSpace
+  , "MetricName": metricName
+  , "Dimensions": dimensions
+  , "Statistics": stat
+  , "StartTime": start
+  , "EndTime": end
+  , "Period": 86400 -- 1Day
+  }
+  where
+  nameSpace = show ms.nameSpace
+
+  metricName = show ms.metricName
+
+  dimensions = ms.dimensions <#> toInternalDimension
+
+  stat = statistics <#> show
+
+  start = fromDateTime range.start
+
+  end = fromDateTime range.end
 
 foreign import getMetricStatisticsImpl :: Fn2 CloudWatch InternalGetMetricsStatisticsParams (Effect (Promise String))
 
-getMetricStatistics :: forall a. CloudWatch -> { start :: DateTime, end :: DateTime | a } -> InstanceId -> Aff (Either String InternalGetMetricStatisticsOutput)
-getMetricStatistics cw range instanceId = liftEffect curried >>= Promise.toAff <#> parse
+curried ::
+  forall a.
+  CloudWatch ->
+  { start :: DateTime, end :: DateTime | a } ->
+  Statistics ->
+  MetricSettings ->
+  Effect (Promise String)
+curried cw range statistics ms = runFn2 getMetricStatisticsImpl cw params
   where
-  parse :: String -> Either String InternalGetMetricStatisticsOutput
+  params :: InternalGetMetricsStatisticsParams
+  params = toInternalGetMetricStatisticsParams range statistics ms
+
+getMetricStatisticsMaximum ::
+  forall a.
+  CloudWatch ->
+  { start :: DateTime, end :: DateTime | a } ->
+  Statistics ->
+  MetricSettings ->
+  Aff (Either String (GetMetricStatisticsOutput MetricDatapointMaximum))
+getMetricStatisticsMaximum cw range statistics ms = liftEffect (curried cw range statistics ms) >>= Promise.toAff <#> parse
+  where
+  parse :: String -> Either String (GetMetricStatisticsOutput MetricDatapointMaximum)
   parse = (parseJson >=> decodeJson) >>> lmap handleError
 
-  curried :: Effect (Promise String)
-  curried =
-    runFn2 getMetricStatisticsImpl cw
-      { "Namespace": "AWS/EC2"
-      , "MetricName": "CPUUtilization"
-      , "Dimensions": [ { "Name": "InstanceId", "Value": unwrap instanceId } ]
-      , "Statistics": [ "Maximum" ]
-      , "StartTime": fromDateTime range.start
-      , "EndTime": fromDateTime range.end
-      , "Period": 86400
-      }
+getMetricStatisticsAverage ::
+  forall a.
+  CloudWatch ->
+  { start :: DateTime, end :: DateTime | a } ->
+  Statistics ->
+  MetricSettings ->
+  Aff (Either String (GetMetricStatisticsOutput MetricDatapointAverage))
+getMetricStatisticsAverage cw range statistics ms = liftEffect (curried cw range statistics ms) >>= Promise.toAff <#> parse
+  where
+  parse :: String -> Either String (GetMetricStatisticsOutput MetricDatapointAverage)
+  parse = (parseJson >=> decodeJson) >>> lmap handleError

--- a/src/AWS/CloudWatch/Types.purs
+++ b/src/AWS/CloudWatch/Types.purs
@@ -1,0 +1,76 @@
+module AWS.CloudWatch.Types where
+
+import Data.Newtype (class Newtype)
+import Prelude (class Show)
+
+data Statistic
+  = Minimum
+  | Maximum
+  | Average
+  | SampleCount
+  | Sum
+
+instance showStatistic :: Show Statistic where
+  show Minimum = "Minimum"
+  show Maximum = "Maximum"
+  show Average = "Average"
+  show SampleCount = "SampleCount"
+  show Sum = "Sum"
+
+type Statistics
+  = Array Statistic
+
+newtype DimensionValue
+  = DimensionValue String
+
+derive instance ntDimensionValue :: Newtype DimensionValue _
+
+derive newtype instance showDimensionValue :: Show DimensionValue
+
+data NameSpace
+  = EC2
+  | ECS
+
+instance showNameSpace :: Show NameSpace where
+  show EC2 = "AWS/EC2"
+  show ECS = "AWS/ECS"
+
+data DimensionName
+  = EC2InstanceId
+  | ClusterName
+
+instance showDimensionName :: Show DimensionName where
+  show EC2InstanceId = "InstanceId"
+  show ClusterName = "ClusterName"
+
+data MetricName
+  = CPUUtilization
+  | CPUReservation
+
+instance showMetricName :: Show MetricName where
+  show CPUUtilization = "CPUUtilization"
+  show CPUReservation = "CPUReservation"
+
+type Dimension
+  = { name :: DimensionName, value :: DimensionValue }
+
+type MetricSettings
+  = { nameSpace :: NameSpace
+    , metricName :: MetricName
+    , dimensions :: Array Dimension
+    }
+
+type Raw
+  = ( "Timestamp" :: String, "Unit" :: String )
+
+type MetricDatapointAverage
+  = { "Average" :: Number | Raw }
+
+type MetricDatapointMaximum
+  = { "Maximum" :: Number | Raw }
+
+type GetMetricStatisticsOutput a
+  = { "ResponseMetadata" :: { "RequestId" :: String }
+    , "Label" :: String
+    , "Datapoints" :: Array a
+    }


### PR DESCRIPTION
Extract code to a new `Types.purs` to make the "main" file more readable.